### PR TITLE
Problem in rails console with active record

### DIFF
--- a/irb/env/active_record.rb
+++ b/irb/env/active_record.rb
@@ -1,8 +1,10 @@
 module IRB::Env::ActiveRecord
   def self.switch_env(old_env, env)
-    ::ActiveRecord::Base.clear_cache! if ::ActiveRecord::Base.respond_to? :clear_cache
-    ::ActiveRecord::Base.clear_all_connections!
-    ::ActiveRecord::Base.establish_connection
+    if ::ActiveRecord::Base.connected?
+      ::ActiveRecord::Base.clear_cache! if ::ActiveRecord::Base.respond_to? :clear_cache
+      ::ActiveRecord::Base.clear_all_connections!
+      ::ActiveRecord::Base.establish_connection
+    end
   end
 
   IRB::Env.add_handler(self) if defined?(::ActiveRecord::Base)


### PR DESCRIPTION
If I run tests in rails console I get:

```
activerecord-3.2.8/lib/active_record/connection_adapters/abstract/connection_specification.rb:47:in `resolve_hash_connection'
```

In rails console test no such problem occurs.

If it works in development environment, wouldn't there be problems with development data in the db breaking tests? How is this solved?
