### PR TITLE
Make gem loading work when GEM_PATH isn't defined

### DIFF
--- a/irb/gem_loader.rb
+++ b/irb/gem_loader.rb
@@ -3,8 +3,8 @@ module IRB
     def self.setup
       if defined?(Bundler)
         # We make everything in the global gemset available, bypassing Bundler
-        global_gemset = ENV['GEM_PATH'].split(':').grep(/ruby.*@global/).first
-        Dir["#{global_gemset}/gems/*"].each { |p| $LOAD_PATH << "#{p}/lib" } if global_gemset
+        global_gemset = ( ENV["GEM_PATH"] || `rvm $(rvm current) do gem env path`.chop ).split(':').grep(/ruby.*@global/).first
+        Dir["#{global_gemset}/gems/*"].each { |path| $LOAD_PATH << "#{path}/lib" } if global_gemset
       end
     end
     setup


### PR DESCRIPTION
Hi, your setup is impressive, thanks! I am looking into replicating/integrating it with my current VIM settings etc. 

I had switched from RVM to rbenv months ago but I have now switched back so I could use your simple installation procedure without having to figure out how to make it work with rbenv. I am not sure why though, on my system GEM_PATH isn't defined after installing RVM and refreshing my shell (ZSH).

I have found though that 

``` ruby
`rvm $(rvm current) do gem env path`.chop
```

yields the same return (seems to work both with and without an .rvmrc file in the project's folder); so I have made a little change to use this command if GEM_PATH isn't defined like in my case.

Please let me know if otherwise there is a reason -and a fix- why this variable isn't automatically defined in some scenarios.

Thanks!
