### PR TITLE
Changed RBENV check to be platform inclusive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TARGETS = $(HOME)/.pryrc $(HOME)/.irbrc
 SHELL = /usr/bin/env bash
 CWD = $(shell pwd)
 RVM=$(shell ls -d {~/.,/usr/local/}rvm 2>/dev/null | head -1)
-RBENV=$(shell ls -d {~/.,/usr/local/,/opt/boxen/}rbenv 2>/dev/null | head -1)
+RBENV=$(shell echo $RBENV_ROOT)
 
 ifneq ($(RVM),)
   RUBIES=$(shell ls ${RVM}/rubies | grep -v '^default$$')


### PR DESCRIPTION
Since `rbenv` sets environment variables, this is a more sensible way to check for `rbenv`.

I'm sure RVM sets env variables too, so that would be a good change too.

This change was made, because this currently doesn't support homebrew installed `rbenv`
